### PR TITLE
ENH: vault: add support for polyhashing

### DIFF
--- a/api/sys_init.go
+++ b/api/sys_init.go
@@ -39,6 +39,7 @@ type InitRequest struct {
 	RecoveryThreshold int      `json:"recovery_threshold"`
 	RecoveryPGPKeys   []string `json:"recovery_pgp_keys"`
 	RootTokenPGPKey   string   `json:"root_token_pgp_key"`
+	PolyhashPasswords []string `json:"polyhash"`
 }
 
 type InitStatusResponse struct {

--- a/api/sys_seal.go
+++ b/api/sys_seal.go
@@ -25,8 +25,8 @@ func (c *Sys) ResetUnsealProcess() (*SealStatusResponse, error) {
 	return sealStatusRequest(c, r)
 }
 
-func (c *Sys) Unseal(shard string) (*SealStatusResponse, error) {
-	body := map[string]interface{}{"key": shard}
+func (c *Sys) Unseal(shard string, polyhash bool) (*SealStatusResponse, error) {
+	body := map[string]interface{}{"key": shard, "polyhash": polyhash}
 
 	r := c.c.NewRequest("PUT", "/v1/sys/unseal")
 	if err := r.SetJSONBody(body); err != nil {

--- a/command/unseal.go
+++ b/command/unseal.go
@@ -19,9 +19,10 @@ type UnsealCommand struct {
 }
 
 func (c *UnsealCommand) Run(args []string) int {
-	var reset bool
+	var reset, polyhash bool
 	flags := c.Meta.FlagSet("unseal", meta.FlagSetDefault)
 	flags.BoolVar(&reset, "reset", false, "")
+	flags.BoolVar(&polyhash, "polyhash", false, "")
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -71,7 +72,7 @@ func (c *UnsealCommand) Run(args []string) int {
 				return 1
 			}
 		}
-		sealStatus, err = client.Sys().Unseal(strings.TrimSpace(value))
+		sealStatus, err = client.Sys().Unseal(strings.TrimSpace(value), polyhash)
 	}
 
 	if err != nil {
@@ -122,6 +123,9 @@ Unseal Options:
 
   -reset                  Reset the unsealing process by throwing away
                           prior keys in process to unseal the vault.
+
+  -polyhash               Indicate the server that this is
+                          a password used for polyhashing.
 
 `
 	return strings.TrimSpace(helpText)

--- a/polyhash/flags.go
+++ b/polyhash/flags.go
@@ -1,0 +1,26 @@
+package polyhash
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type PolyhashPasswordsFlag []string
+
+func (p *PolyhashPasswordsFlag) String() string {
+	return fmt.Sprint(*p)
+}
+
+func (p *PolyhashPasswordsFlag) Set(value string) error {
+	if len(*p) > 0 {
+		return errors.New("polyhash can only be specified once")
+	}
+
+	splitValues := strings.Split(value, ",")
+	for _, password := range splitValues {
+		*p = append(*p, password)
+	}
+
+	return nil
+}

--- a/polyhash/polyhash.go
+++ b/polyhash/polyhash.go
@@ -1,0 +1,87 @@
+package polyhash
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+
+	"fmt"
+)
+
+const SHARE_LENGTH = 32
+const SALT_LENGTH = 16
+
+func check_error(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+// xorBytes returns the xor'ed value of it's inputs
+func xorBytes(a, b []byte) []byte {
+	n := len(a)
+	dst := make([]byte, n)
+	for i := 0; i < n; i++ {
+		dst[i] = a[i] ^ b[i]
+	}
+	return dst
+}
+
+// computeHash helps to compute the salted hash from the password
+func computeHash(salt []byte, password string) []byte {
+	hash_func := sha256.New()
+	hash_func.Write(salt)
+	hash_func.Write([]byte(password))
+	return hash_func.Sum(nil)
+}
+
+// StoreShareInformation takes in list of passwords, and a list of shares and
+// returns a list of polyhashes of the form "share number,share xor hash,salt"
+func StoreShareInformation(passwords []string, shares [][]byte) []string {
+
+	var shareno int = 1
+	salt := make([]byte, SALT_LENGTH)
+	var polyhashentry string
+	var polyhashdb []string
+	var err error
+
+	for i := 0; i < len(shares); i++ {
+		// Generate a random salt
+		_, err = rand.Read(salt)
+		check_error(err)
+
+		// Compute the share_xor_hashes
+		hash := computeHash(salt, passwords[i])
+		share_xor_hash := xorBytes(shares[i][:len(shares[i])-1], hash)
+
+		// FIXME probably concatenating this tring is not the best idea
+		polyhashentry = fmt.Sprintf("%02x,%064x,%032x\n", shareno,
+			share_xor_hash, salt)
+
+		polyhashdb = append(polyhashdb, polyhashentry)
+		shareno += 1
+	}
+
+	return polyhashdb
+}
+
+// RecoverShareFromPolyhash recovers the share value from polyhashentry
+// using the share number and password that are passed in
+func RecoverShareFromPolyhash(share_num int, polyhashdb []string, password string) []byte {
+
+	share_xor_hash := make([]byte, SHARE_LENGTH)
+	salt := make([]byte, SALT_LENGTH)
+	var number int
+
+	for _, entry := range polyhashdb {
+		fmt.Sscanf(entry, "%x,%x,%x", &number, &share_xor_hash, &salt)
+		if number == share_num {
+			break
+		}
+	}
+
+	hash := computeHash(salt, password)
+	share := xorBytes(share_xor_hash, hash)
+	shareno := byte(share_num)
+	share = append(share, shareno)
+	return share
+}

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -241,6 +241,10 @@ type SealConfig struct {
 
 	// How many keys to store, for seals that support storage.
 	StoredShares int `json:"stored_shares"`
+
+	// This is a list of Shard information that each of them contains shard
+	// number, shard xor hash and salt. It is created at the init -polyhash
+	PolyhashEntries []string `json:"polyhash"`
 }
 
 // Validate is used to sanity check the seal configuration
@@ -292,6 +296,7 @@ func (s *SealConfig) Clone() *SealConfig {
 		Nonce:           s.Nonce,
 		Backup:          s.Backup,
 		StoredShares:    s.StoredShares,
+		PolyhashEntries: s.PolyhashEntries,
 	}
 	if len(s.PGPKeys) > 0 {
 		ret.PGPKeys = make([]string, len(s.PGPKeys))


### PR DESCRIPTION
Vault could benefit from polyhashing for the unseal procedure.
Add support for polyhashing for the init and unseal procedures.